### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -18,6 +18,10 @@ class ProductsController < ApplicationController
     end
   end
 
+  def show
+    @product = Product.find(params[:id])
+  end
+
   private
 
   def product_params

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -131,7 +131,7 @@
       <% if @products.any? %>
         <% @products.each do |product| %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to product_path(product.id) do %>
             <div class='item-img-content'>
               <%= image_tag product.image, class: "item-img" %>
 

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -131,6 +131,7 @@
       <% if @products.any? %>
         <% @products.each do |product| %>
           <li class='list'>
+
             <%= link_to product_path(product.id) do %>
             <div class='item-img-content'>
               <%= image_tag product.image, class: "item-img" %>
@@ -153,6 +154,7 @@
               </div>
             </div>
             <% end %>
+            
           </li>
         <% end %>
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -3,68 +3,78 @@
 <%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
-    <h2 class="name">
-      <%= "商品名" %>
-    </h2>
-    <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
+      <h2 class="name">
+        <%= @product.product_name %>
+      </h2>
+      <div class="item-img-content">
+        <%= image_tag @product.image.attached? ? url_for(@product.image) : "item-sample.png" ,class:"item-box-img" %>
+        <%# 商品が売れている場合は、sold outを表示しましょう %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+        <%# //商品が売れている場合は、sold outを表示しましょう %>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
-    </div>
-    <div class="item-price-box">
-      <span class="item-price">
-        ¥ 999,999,999
-      </span>
-      <span class="item-postage">
-        <%= "配送料負担" %>
-      </span>
-    </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <div class="item-price-box">
+        <span class="item-price">
+          ¥ <%= @product.price %>
+        </span>
+        <span class="item-postage">
+          <%= @product.shipping_charge.name %>
+        </span>
+      </div>
 
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
+    <% if user_signed_in? %>
+      <% if current_user == @product.user %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <% else %>
+
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+
+
+        <%# 商品購入ボタン %>
+      <% end %>
+    <% end %>
+
+
+
+
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @product.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @product.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @product.days_to_shipping.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -22,30 +22,18 @@
           <%= @product.shipping_charge.name %>
         </span>
       </div>
-
-
-
-
-
     <% if user_signed_in? %>
       <% if current_user == @product.user %>
         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>
-
         <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
         <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
         <%# 商品購入ボタン %>
       <% end %>
     <% end %>
-
-
-
-
 
     <div class="item-explain-box">
       <span><%= @product.description %></span>
@@ -113,9 +101,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @product.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   get 'products/index'
   get 'products/new'
   root to: 'products#index'
-  resources :products, only: [:new, :create, :index]
+  resources :products, only: [:new, :create, :index, :show]
 end


### PR DESCRIPTION
# What
- link_toをクリックすると商品詳細画面へ遷移
- 商品詳細画面で、その商品の情報や画像を表示
- ユーザーによって表示されるボタンが変化するように条件分岐

# Why
商品詳細表示機能の実装のため


ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/f1d5b0f82ae91a2622d99bbee63ae8a2

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/7cf52929d8811543552496cf7fc0a6fa

ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
※ 購入機能未実装のためなし

ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/15414f79eb7899bd7a88426824cddf43