### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -21,15 +21,12 @@ class ProductsController < ApplicationController
   end
 
   def show
-    # @product = Product.find(params[:id])
   end
 
   def edit
-    # @product = Product.find(params[:id])
   end
 
   def update
-    @product = Product.find(params[:id])
     if @product.update(product_params)
     redirect_to product_path
     else

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,8 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :authenticate_user!, only: [:edit, :update]
+  before_action :set_product, only: [:edit, :update]
+  before_action :correct_user, only: [:edit, :update]
 
   def index
     @products = Product.order("created_at DESC")
@@ -28,10 +31,24 @@ class ProductsController < ApplicationController
 
   def update
     @product = Product.find(params[:id])
-    @product.update(product_params)
+    if @product.update(product_params)
+    redirect_to product_path
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   private
+
+  def set_product
+    @product = Product.find(params[:id])
+  end
+
+  def correct_user
+    unless current_user == @product.user
+      redirect_to products_path, alert: '他のユーザーの投稿を編集することはできません。'
+    end
+  end
 
   def product_params
     params.require(:product).permit(:product_name, :description, :category_id, :condition_id, :shipping_charge_id, :prefecture_id, :days_to_shipping_id, :price, :image).merge(user_id: current_user.id)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -22,6 +22,15 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
   end
 
+  def edit
+    @product = Product.find(params[:id])
+  end
+
+  def update
+    @product = Product.find(params[:id])
+    @product.update(product_params)
+  end
+
   private
 
   def product_params

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,5 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :authenticate_user!, only: [:edit, :update]
   before_action :set_product, only: [:edit, :update]
   before_action :correct_user, only: [:edit, :update]
 
@@ -22,11 +21,11 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @product = Product.find(params[:id])
+    # @product = Product.find(params[:id])
   end
 
   def edit
-    @product = Product.find(params[:id])
+    # @product = Product.find(params[:id])
   end
 
   def update

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_product, only: [:edit, :update]
+  before_action :set_product, only: [:edit, :update, :show]
   before_action :correct_user, only: [:edit, :update]
 
   def index

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with(model: @product, local: true) do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :product_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, [['---', 0], ['メンズ', 1], ['レディース', 2], ['ベビー・キッズ', 3],['インテリア・住まい・小物', 4], ['本・音楽・ゲーム', 5], ['おもちゃ・ホビー・グッズ', 6],['家電・スマホ・カメラ', 7], ['スポーツ・レジャー', 8], ['ハンドメイド', 9], ['その他', 10]], :last, :first, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, [['---', 0], ['新品・未使用', 1], ['未使用に近い', 2], ['目立った傷や汚れなし', 3],['やや傷や汚れあり', 4], ['傷や汚れあり', 5], ['全体的に状態が悪い', 6]], :last, :first, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,18 +71,19 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_charge_id, [['---', 0], ['着払い(購入者負担)', 1], ['送料込み(出品者負担)', 2]], :last, :first, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, [['---', 0], ['北海道', 1], ['青森県', 2], ['岩手県', 3], ['宮城県', 4], ['秋田県', 5], ['山形県', 6],['福島県', 7], ['茨城県', 8], ['栃木県', 9], ['群馬県', 10], ['埼玉県', 11], ['千葉県', 12], ['東京都', 13],['神奈川県', 14], ['新潟県', 15], ['富山県', 16], ['石川県', 17], ['福井県', 18], ['山梨県', 19], ['長野県', 20],['岐阜県', 21], ['静岡県', 22], ['愛知県', 23], ['三重県', 24], ['滋賀県', 25], ['京都府', 26], ['大阪府', 27],['兵庫県', 28], ['奈良県', 29], ['和歌山県', 30], ['鳥取県', 31], ['島根県', 32], ['岡山県', 33], ['広島県', 34],['山口県', 35], ['徳島県', 36], ['香川県', 37], ['愛媛県', 38], ['高知県', 39], ['福岡県', 40], ['佐賀県', 41],['長崎県', 42], ['熊本県', 43], ['大分県', 44], ['宮崎県', 45], ['鹿児島県', 46], ['沖縄県', 47]], :last, :first, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:days_to_shipping_id, [['---', 0], ['1~2日で発送', 1], ['2~3日で発送', 2], ['4~7日で発送', 3]], :last, :first, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
+
     </div>
     <%# /配送について %>
 
@@ -101,7 +100,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +140,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', product_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -24,7 +24,9 @@
       </div>
     <% if user_signed_in? %>
       <% if current_user == @product.user %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+
+        <%= link_to "商品の編集", edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
+
         <p class="or-text">or</p>
         <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   get 'products/index'
   get 'products/new'
   root to: 'products#index'
-  resources :products, only: [:new, :create, :index, :show]
+  resources :products, only: [:new, :create, :index, :show, :edit, :update]
 end


### PR DESCRIPTION
# What
- 必要な情報を適切に入力して「変更する」ボタンを押すと、商品情報（商品画像・商品名・商品の状態など）を編集できること。
- 何も編集せずに「変更する」ボタンを押しても、画像無しの商品にならないこと。
- ページ下部の「もどる」ボタンを押すと、編集途中の情報は破棄され、商品詳細表示ページに遷移すること。
- ログイン状態の場合は、自身が出品した販売中商品の商品情報編集ページに遷移できること。
- （こちらは未実装です。）ログイン状態の場合でも、自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること。
- ログイン状態の場合でも、自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移すること。
- ログアウト状態の場合は、商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移すること。
- 商品出品時とほぼ同じ見た目の商品情報編集ページが表示されること。
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は、商品情報編集画面を開いた時点で表示されること（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）。
- 編集が完了したら、商品詳細表示ページに遷移し、変更された商品情報が表示されること。
- エラーハンドリングができること（入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示されること）。
- エラーハンドリングによって編集ページに戻った場合でも、入力済みの項目（画像・販売手数料・販売利益以外）は消えないこと。
- エラーハンドリングの際、重複したエラーメッセージが表示されないこと。

# Why
商品情報編集機能の実装のため



- ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/9b7fe867ac0e6de2a0be2057c74c363c

- 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/bdba3e8c4e5e228fe0249c7dd6e35dbf

- 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/03432662f3ae247d253e5983d0f5f2f0

- 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/9a8890fad568aaa710162d30c4b4c6c9

- ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/72483cbbed11c1d5bdf0005aa64fe338

- ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
※未作業のため該当なし

- ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/9b36f22685f8787ca537dc76dcf9ff06

- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/5be0026a3df0b22b4ee9d8a9467306f0